### PR TITLE
fix(docker-compsose): add host.docker.internal as extra hosts

### DIFF
--- a/docker-falcon/docker-compose-local.yaml
+++ b/docker-falcon/docker-compose-local.yaml
@@ -1,41 +1,67 @@
-version: '2.2'
 services:
 # PROMETHEUS ==============================================================================
   falcon-prometheus:
     image: prom/prometheus:latest
     container_name: falcon-prometheus
+    # TODO: REMOVE
+    # Most Governify microservices have a hard-coded reference to the "host.docker.internal" address,
+    # so this is left here to make it work in all systems. This is a hack and all services
+    # must be changed so the dependencies are passed using environment variables, without doing
+    # any assumptions about the user's deployment.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     depends_on:
-      - falcon-assets-manager
+      falcon-assets-manager:
+        condition: service_healthy
     command:
       - --config.file=/etc/prometheus/config.yml
     volumes:
       - ../config/prometheus:/etc/prometheus:ro
     volumes_from:
       - falcon-assets-manager:ro
+    networks:
+      - governify-falcon
     ports:
      - 5900:9090
 # =========================================
   falcon-render:
     container_name: falcon-render
     image: governify/render:develop
+    # TODO: REMOVE
+    # Most Governify microservices have a hard-coded reference to the "host.docker.internal" address,
+    # so this is left here to make it work in all systems. This is a hack and all services
+    # must be changed so the dependencies are passed using environment variables, without doing
+    # any assumptions about the user's deployment.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       - NODE_ENV=development
       - PORT=5100
       - LOGIN_USER=${LOGIN_USER:?}
       - LOGIN_PASSWORD=${LOGIN_PASSWORD:?}
-      - DEFAULT_VIEW=http://host.docker.internal:5200/api/v1/public/renders/index/view.html
-      - DEFAULT_CONTROLLER=http://host.docker.internal:5200/api/v1/public/renders/index/controller.js
-      - DEFAULT_MODEL=http://host.docker.internal:5200/api/v1/public/renders/index/model.json
+      - DEFAULT_VIEW=http://falcon-assets-manager:5200/api/v1/public/renders/index/view.html
+      - DEFAULT_CONTROLLER=http://falcon-assets-manager:5200/api/v1/public/renders/index/controller.js
+      - DEFAULT_MODEL=http://falcon-assets-manager:5200/api/v1/public/renders/index/model.json
       - GOV_INFRASTRUCTURE=${GOV_INFRASTRUCTURE:?}
       - LAYOUT=bootstrap5.html
+    networks:
+      - governify-falcon
     ports:
       - 5100:5100
     depends_on:
-      - falcon-assets-manager
+      falcon-assets-manager:
+        condition: service_healthy
 # =========================================
   falcon-assets-manager:
     container_name: falcon-assets-manager
     image: 'governify/assets-manager:develop'
+    # TODO: REMOVE
+    # Most Governify microservices have a hard-coded reference to the "host.docker.internal" address,
+    # so this is left here to make it work in all systems. This is a hack and all services
+    # must be changed so the dependencies are passed using environment variables, without doing
+    # any assumptions about the user's deployment.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       - NODE_ENV=production
       - PORT=5200
@@ -49,32 +75,56 @@ services:
       - GOV_INFRASTRUCTURE=/home/project/public/infrastructure-local.yaml
     volumes:
       - '../assets:/home/project'
-    mem_limit: 900m
     restart: 'unless-stopped'
+    networks:
+      - governify-falcon
     ports:
       - 5200:5200
+    healthcheck:
+      test: wget --quiet --tries=1 --spider http://127.0.0.1/api/v1/public/infrastructure.yaml || exit 1
+      interval: 5s
 # =========================================
   falcon-reporter:
     container_name: falcon-reporter
     image: governify/reporter:develop
+    # TODO: REMOVE
+    # Most Governify microservices have a hard-coded reference to the "host.docker.internal" address,
+    # so this is left here to make it work in all systems. This is a hack and all services
+    # must be changed so the dependencies are passed using environment variables, without doing
+    # any assumptions about the user's deployment.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       - NODE_ENV=development
       - PORT=5300
       - DB_HOST=influxdb
       - GOV_INFRASTRUCTURE=${GOV_INFRASTRUCTURE:?}
+    networks:
+      - governify-falcon
     depends_on:
-      - falcon-influx-reporter
-      - falcon-assets-manager
+      falcon-influx-reporter:
+        condition: service_started
+      falcon-assets-manager:
+        condition: service_healthy
     ports:
       - 5300:5300
 # =========================================
   falcon-influx-reporter:
     container_name: falcon-influx-reporter
     image: 'influxdb:1.8.4-alpine'
+    # TODO: REMOVE
+    # Most Governify microservices have a hard-coded reference to the "host.docker.internal" address,
+    # so this is left here to make it work in all systems. This is a hack and all services
+    # must be changed so the dependencies are passed using environment variables, without doing
+    # any assumptions about the user's deployment.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       - INFLUXDB_BIND_ADDRESS=:8088
     volumes:
       - 'falcon-influxdb-volume:/var/lib/influxdb'
+    networks:
+      - governify-falcon
     ports:
       - 5002:8086
       - 8088:8088
@@ -82,62 +132,113 @@ services:
   falcon-registry:
     container_name: falcon-registry
     image: 'governify/registry:develop'
+    # TODO: REMOVE
+    # Most Governify microservices have a hard-coded reference to the "host.docker.internal" address,
+    # so this is left here to make it work in all systems. This is a hack and all services
+    # must be changed so the dependencies are passed using environment variables, without doing
+    # any assumptions about the user's deployment.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       - NODE_ENV=development
       - PORT=5400
       - DB_HOST=mongo_registry
       - GOV_INFRASTRUCTURE=${GOV_INFRASTRUCTURE:?}
     depends_on:
-      - falcon-assets-manager
-      - falcon-mongo-registry
+      falcon-mongo-registry:
+        condition: service_started
+      falcon-assets-manager:
+        condition: service_healthy
+    networks:
+      - governify-falcon
     ports:
       - 5400:5400
 # =========================================
   falcon-mongo-registry:
     container_name: falcon-mongo-registry
     image: mongo
+    # TODO: REMOVE
+    # Most Governify microservices have a hard-coded reference to the "host.docker.internal" address,
+    # so this is left here to make it work in all systems. This is a hack and all services
+    # must be changed so the dependencies are passed using environment variables, without doing
+    # any assumptions about the user's deployment.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     volumes:
       - 'falcon-registry-db-volume:/data/db'
     ports:
       - 5001:27017
+    networks:
+      - governify-falcon
 # =========================================
   falcon-collector-dynamic:
     container_name: falcon-collector-dynamic
     image: 'governify/collector-dynamic:develop'
+    # TODO: REMOVE
+    # Most Governify microservices have a hard-coded reference to the "host.docker.internal" address,
+    # so this is left here to make it work in all systems. This is a hack and all services
+    # must be changed so the dependencies are passed using environment variables, without doing
+    # any assumptions about the user's deployment.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       - NODE_ENV=development
       - PORT=5501
       - GOV_INFRASTRUCTURE=${GOV_INFRASTRUCTURE:?}
-    mem_limit: 400m
     depends_on:
-      - falcon-assets-manager
+      falcon-assets-manager:
+        condition: service_healthy
+    networks:
+      - governify-falcon
     ports:
       - 5501:5501
 # =========================================
   falcon-dashboard:
     container_name: falcon-dashboard
     image: governify/dashboard:develop
+    # TODO: REMOVE
+    # Most Governify microservices have a hard-coded reference to the "host.docker.internal" address,
+    # so this is left here to make it work in all systems. This is a hack and all services
+    # must be changed so the dependencies are passed using environment variables, without doing
+    # any assumptions about the user's deployment.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       - NODE_ENV=development
       - GOV_INFRASTRUCTURE=${GOV_INFRASTRUCTURE:?}
-      - INFLUX_URL=http://host.docker.internal:5002
+      - INFLUX_URL=http://falcon-influx-reporter:8086
       - GF_PATHS_PLUGINS=/usr/share/grafana/plugins
+    networks:
+      - governify-falcon
     ports:
       - 5600:3000
 # =========================================
   falcon-director:
     container_name: falcon-director
     image: 'governify/director:develop'
+    # TODO: REMOVE
+    # Most Governify microservices have a hard-coded reference to the "host.docker.internal" address,
+    # so this is left here to make it work in all systems. This is a hack and all services
+    # must be changed so the dependencies are passed using environment variables, without doing
+    # any assumptions about the user's deployment.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       - NODE_ENV=development
       - PORT=5800
       - GOV_INFRASTRUCTURE=${GOV_INFRASTRUCTURE:?}
       - INFLUXDB_BIND_ADDRESS=:8088
-    mem_limit: 400m
     depends_on:
-      - falcon-assets-manager
+      falcon-assets-manager:
+        condition: service_healthy
+    networks:
+      - governify-falcon
     ports:
       - 5800:5800
+
 volumes:
   falcon-influxdb-volume: null
   falcon-registry-db-volume: null
+
+networks:
+  governify-falcon

--- a/docker-falcon/docker-compose.yaml
+++ b/docker-falcon/docker-compose.yaml
@@ -4,6 +4,13 @@ services:
   falcon-prometheus:
     image: prom/prometheus:latest
     container_name: falcon-prometheus
+    # TODO: REMOVE
+    # Most Governify microservices have a hard-coded reference to the "host.docker.internal" address,
+    # so this is left here to make it work in all systems. This is a hack and all services
+    # must be changed so the dependencies are passed using environment variables, without doing
+    # any assumptions about the user's deployment.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     depends_on:
       - falcon-assets-manager
     command:
@@ -18,6 +25,13 @@ services:
   certbot:
     image: certbot/certbot
     restart: unless-stopped
+    # TODO: REMOVE
+    # Most Governify microservices have a hard-coded reference to the "host.docker.internal" address,
+    # so this is left here to make it work in all systems. This is a hack and all services
+    # must be changed so the dependencies are passed using environment variables, without doing
+    # any assumptions about the user's deployment.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     volumes:
       - ../data/certbot/conf:/etc/letsencrypt
       - ../data/certbot/www:/var/www/certbot
@@ -50,6 +64,13 @@ services:
   falcon-render:
     container_name: falcon-render
     image: governify/render:v2.2.0
+    # TODO: REMOVE
+    # Most Governify microservices have a hard-coded reference to the "host.docker.internal" address,
+    # so this is left here to make it work in all systems. This is a hack and all services
+    # must be changed so the dependencies are passed using environment variables, without doing
+    # any assumptions about the user's deployment.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       - NODE_ENV=production
       - PORT=80
@@ -68,6 +89,13 @@ services:
   falcon-assets-manager:
     container_name: falcon-assets-manager
     image: 'governify/assets-manager:v1.4.1'
+    # TODO: REMOVE
+    # Most Governify microservices have a hard-coded reference to the "host.docker.internal" address,
+    # so this is left here to make it work in all systems. This is a hack and all services
+    # must be changed so the dependencies are passed using environment variables, without doing
+    # any assumptions about the user's deployment.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       - NODE_ENV=production
       - PORT=80
@@ -88,6 +116,13 @@ services:
   falcon-reporter:
     container_name: falcon-reporter
     image: governify/reporter:v2.2.0
+    # TODO: REMOVE
+    # Most Governify microservices have a hard-coded reference to the "host.docker.internal" address,
+    # so this is left here to make it work in all systems. This is a hack and all services
+    # must be changed so the dependencies are passed using environment variables, without doing
+    # any assumptions about the user's deployment.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       - NODE_ENV=production
       - PORT=80
@@ -102,6 +137,13 @@ services:
   falcon-influx-reporter:
     container_name: falcon-influx-reporter
     image: 'influxdb:1.8.4-alpine'
+    # TODO: REMOVE
+    # Most Governify microservices have a hard-coded reference to the "host.docker.internal" address,
+    # so this is left here to make it work in all systems. This is a hack and all services
+    # must be changed so the dependencies are passed using environment variables, without doing
+    # any assumptions about the user's deployment.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       - INFLUXDB_BIND_ADDRESS=:8088
     volumes:
@@ -112,6 +154,13 @@ services:
   falcon-registry:
     container_name: falcon-registry
     image: 'governify/registry:v3.4.0'
+    # TODO: REMOVE
+    # Most Governify microservices have a hard-coded reference to the "host.docker.internal" address,
+    # so this is left here to make it work in all systems. This is a hack and all services
+    # must be changed so the dependencies are passed using environment variables, without doing
+    # any assumptions about the user's deployment.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     networks:
       - governify-falcon
     environment:
@@ -124,6 +173,13 @@ services:
 # =========================================
   falcon-mongo-registry:
     container_name: falcon-mongo-registry
+    # TODO: REMOVE
+    # Most Governify microservices have a hard-coded reference to the "host.docker.internal" address,
+    # so this is left here to make it work in all systems. This is a hack and all services
+    # must be changed so the dependencies are passed using environment variables, without doing
+    # any assumptions about the user's deployment.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     image: mongo
     networks:
       - governify-falcon
@@ -133,6 +189,13 @@ services:
   falcon-collector-dynamic:
     container_name: falcon-collector-dynamic
     image: 'governify/collector-dynamic:v1.3.0'
+    # TODO: REMOVE
+    # Most Governify microservices have a hard-coded reference to the "host.docker.internal" address,
+    # so this is left here to make it work in all systems. This is a hack and all services
+    # must be changed so the dependencies are passed using environment variables, without doing
+    # any assumptions about the user's deployment.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     networks:
       - governify-falcon
     environment:
@@ -146,6 +209,13 @@ services:
   falcon-dashboard:
     container_name: falcon-dashboard
     image: governify/dashboard:latest
+    # TODO: REMOVE
+    # Most Governify microservices have a hard-coded reference to the "host.docker.internal" address,
+    # so this is left here to make it work in all systems. This is a hack and all services
+    # must be changed so the dependencies are passed using environment variables, without doing
+    # any assumptions about the user's deployment.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       - NODE_ENV=production
       - GOV_INFRASTRUCTURE=${GOV_INFRASTRUCTURE:?}
@@ -157,6 +227,13 @@ services:
   falcon-director:
     container_name: falcon-director
     image: 'governify/director:v1.4.0'
+    # TODO: REMOVE
+    # Most Governify microservices have a hard-coded reference to the "host.docker.internal" address,
+    # so this is left here to make it work in all systems. This is a hack and all services
+    # must be changed so the dependencies are passed using environment variables, without doing
+    # any assumptions about the user's deployment.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     networks:
       - governify-falcon
     environment:


### PR DESCRIPTION
host.docker.internal only works fine for inter-container communication for MacOS systems, at least according to the documentation we have.

With this approach, Docker will handle all the OS-specific behaviour for us.

This is a workaround that should eventually be removed